### PR TITLE
Change vim key bindings

### DIFF
--- a/.vim/config/commands.vim
+++ b/.vim/config/commands.vim
@@ -1,7 +1,7 @@
-" source init.vim
+" source .vimrc
 
 command! Reload source ~/dotfiles/.vimrc
 
-" Edit init.vim
+" Edit .vimrc
 
-command! Edit vi ~/dotfiles/.vimrc
+command! Vimrc vi ~/dotfiles/.vimrc

--- a/.vim/config/key-map.vim
+++ b/.vim/config/key-map.vim
@@ -2,7 +2,7 @@
 inoremap <silent> jj <ESC>
 
 " open / close nerdtree
-nnoremap :tree :NERDTreeToggle
+nnoremap ::tr :NERDTreeToggle
 
 " fzf: files
 nnoremap :ff :Files     
@@ -12,7 +12,7 @@ nnoremap :fh :History
 nnoremap :fb :BLines 
 
 " vim-table-mode: toggle
-nnoremap :tm :TableModeToggle
+nnoremap ::tm :TableModeToggle
 
 " Reload .vimrc
 nnoremap ::r :Reload

--- a/.vim/config/key-map.vim
+++ b/.vim/config/key-map.vim
@@ -13,3 +13,9 @@ nnoremap :fb :BLines
 
 " vim-table-mode: toggle
 nnoremap :tm :TableModeToggle
+
+" Reload .vimrc
+nnoremap ::r :Reload
+
+" Edit .vimrc
+nnoremap ::v :Vimrc


### PR DESCRIPTION
## Changes
 
- Assign new keys to the commands I defined.
- Use `::xx` format to avoid duplication with the existing key bindings.