### PR TITLE
Add a shell script for setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 !/README.md
 !/.gitignore
+!/install.sh
 !/.zshrc
 !/.zshenv
 !/.ideavimrc


### PR DESCRIPTION
Add a shell script for setup.
It's very time-consuming to create symbolic links on your own every time.

## Changes

- Add install.sh

`install.sh` does the following tasks:
- Create symbolic links
- Tell you what you should install