### PR TITLE
Add vim keymaps for definition jump

### DIFF
--- a/.vim/config/key-map.vim
+++ b/.vim/config/key-map.vim
@@ -19,3 +19,9 @@ nnoremap ::r :Reload
 
 " Edit .vimrc
 nnoremap ::v :Vimrc
+
+" GoTo code navigation.
+nmap <silent> gd <Plug>(coc-definition)
+nmap <silent> gy <Plug>(coc-type-definition)
+nmap <silent> gi <Plug>(coc-implementation)
+nmap <silent> gr <Plug>(coc-references)


### PR DESCRIPTION
## Related URLs

- [coc-nvim](https://github.com/neoclide/coc.nvim)

## Changes

Referenced the repository of coc-nvim, and set up keymaps to the commands to jump to the definition based on it.
